### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can use the "meta" field which you can use to store any additional informati
 To query account balance, just use the `book.balance()` method:
 
 ```js
-const balance = await myBook.balance({
+const { balance } = await myBook.balance({
   account: "Assets:Accounts Receivable",
   client: "Joe Blow"
 });


### PR DESCRIPTION
balance() return an object with { balance, notes }. The documentation implied it was returning a number.